### PR TITLE
add login code, need to setup route structure

### DIFF
--- a/cc/client/public/assets/js/login.js
+++ b/cc/client/public/assets/js/login.js
@@ -1,0 +1,9 @@
+// A $( document ).ready() block.
+$(document).ready(function () {
+    console.log("ready!");
+
+    $('#logIn').on('click',()=>{
+        alert('clicked');
+    })
+
+});

--- a/cc/client/public/login.html
+++ b/cc/client/public/login.html
@@ -1,0 +1,28 @@
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Test Login</title>
+
+        <!-- Bootstrap CSS -->
+        <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
+
+    </head>
+    <body>
+        <h1 class="text-center">Test LinkedIn Auth</h1>
+        
+        <button id="logIn" type="button" class="btn btn-primary">Login</button>
+        
+
+        <!-- jQuery -->
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+        <!-- Bootstrap JavaScript -->
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+        <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+            crossorigin="anonymous"></script>
+        <script src='./assets/js/login.js'></script>
+    </body>
+</html>

--- a/cc/lib/index.js
+++ b/cc/lib/index.js
@@ -1,0 +1,4 @@
+var OAuth2Strategy = require('./oauth2');
+
+exports.Strategy =
+exports.OAuth2Strategy = OAuth2Strategy;

--- a/cc/lib/oauth2.js
+++ b/cc/lib/oauth2.js
@@ -1,0 +1,159 @@
+var util = require('util'),
+   _ = require('underscore')
+  , OAuth2Strategy = require('passport-oauth2')
+  , InternalOAuthError = require('passport-oauth2').InternalOAuthError;
+
+function Strategy(options, verify) {
+  options = options || {};
+  options.authorizationURL = options.authorizationURL || 'https://www.linkedin.com/oauth/v2/authorization';
+  options.tokenURL = options.tokenURL || 'https://www.linkedin.com/oauth/v2/accessToken';
+  options.scope = options.scope || ['r_basicprofile'];
+  options.profileFields = options.profileFields || null;
+
+  //By default we want data in JSON
+  options.customHeaders = options.customHeaders || {"x-li-format":"json"};
+
+  OAuth2Strategy.call(this, options, verify);
+  this.name = 'linkedin';
+  this.profileUrl = 'https://api.linkedin.com/v1/people/~:(' + this._convertScopeToUserProfileFields(options.scope, options.profileFields) + ')';
+}
+
+util.inherits(Strategy, OAuth2Strategy);
+
+Strategy.prototype.userProfile = function(accessToken, done) {
+
+  //LinkedIn uses a custom name for the access_token parameter
+  this._oauth2.setAccessTokenName("oauth2_access_token");
+
+  this._oauth2.get(this.profileUrl, accessToken, function (err, body, res) {
+    if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
+
+    try {
+      var json = JSON.parse(body);
+
+      var profile = { provider: 'linkedin' };
+
+      profile.id = json.id;
+      profile.displayName = json.formattedName;
+      profile.name = {
+                        familyName: json.lastName,
+                        givenName:  json.firstName
+                     };
+      profile.emails = [{ value: json.emailAddress }];
+      profile.photos = [];
+      if (json.pictureUrl) {
+          profile.photos.push({ value: json.pictureUrl });
+      }
+      profile._raw = body;
+      profile._json = json;
+
+      done(null, profile);
+    } catch(e) {
+      done(e);
+    }
+  });
+}
+
+
+
+
+Strategy.prototype._convertScopeToUserProfileFields = function(scope, profileFields) {
+  var self = this;
+  var map = {
+    'r_basicprofile':   [
+      'id',
+      'first-name',
+      'last-name',
+      'picture-url',
+      'picture-urls::(original)',
+      'formatted-name',
+      'maiden-name',
+      'phonetic-first-name',
+      'phonetic-last-name',
+      'formatted-phonetic-name',
+      'headline',
+      'location:(name,country:(code))',
+      'industry',
+      'distance',
+      'relation-to-viewer:(distance,connections)',
+      'current-share',
+      'num-connections',
+      'num-connections-capped',
+      'summary',
+      'specialties',
+      'positions',
+      'site-standard-profile-request',
+      'api-standard-profile-request:(headers,url)',
+      'public-profile-url'
+    ],
+    'r_emailaddress':   ['email-address'],
+    'r_fullprofile':   [
+      'last-modified-timestamp',
+      'proposal-comments',
+      'associations',
+      'interests',
+      'publications',
+      'patents',
+      'languages',
+      'skills',
+      'certifications',
+      'educations',
+      'courses',
+      'volunteer',
+      'three-current-positions',
+      'three-past-positions',
+      'num-recommenders',
+      'recommendations-received',
+      'mfeed-rss-url',
+      'following',
+      'job-bookmarks',
+      'suggestions',
+      'date-of-birth',
+      'member-url-resources:(name,url)',
+      'related-profile-views',
+      'honors-awards'
+    ]
+  };
+
+  var fields = [];
+
+  // To obtain pre-defined field mappings
+  if(Array.isArray(scope) && profileFields === null)
+  {
+    if(scope.indexOf('r_basicprofile') === -1){
+      scope.unshift('r_basicprofile');
+    }
+
+    scope.forEach(function(f) {
+      if (typeof map[f] === 'undefined') return;
+
+      if (Array.isArray(map[f])) {
+        Array.prototype.push.apply(fields, map[f]);
+      } else {
+        fields.push(map[f]);
+      }
+    });
+  }else if (Array.isArray(profileFields)){
+    fields = profileFields;
+  }
+
+  return fields.join(',');
+}
+
+
+
+Strategy.prototype.authorizationParams = function(options) {
+
+  var params = {};
+
+  // LinkedIn requires state parameter. It will return an error if not set.
+  if (options.state) {
+    params['state'] = options.state;
+  }
+  return params;
+}
+
+
+
+
+module.exports = Strategy;

--- a/cc/server.js
+++ b/cc/server.js
@@ -1,0 +1,118 @@
+const express = require('express')
+    , passport = require('passport')
+    , LinkedinStrategy = require('../lib').Strategy;
+
+// API Access link for creating client ID and secret:
+const LINKEDIN_CLIENT_ID = "78xlkz34c94sm1";
+const LINKEDIN_CLIENT_SECRET = "ZhytKExkzWeIfnU1";
+
+// Passport session setup.
+//   To support persistent login sessions, Passport needs to be able to
+//   serialize users into and deserialize users out of the session.  Typically,
+//   this will be as simple as storing the user ID when serializing, and finding
+//   the user by ID when deserializing.  However, since this example does not
+//   have a database of user records, the complete Linkedin profile is
+//   serialized and deserialized.
+passport.serializeUser(function (user, done) {
+    done(null, user);
+});
+
+passport.deserializeUser(function (obj, done) {
+    done(null, obj);
+});
+
+// Use the LinkedinStrategy within Passport.
+//   Strategies in Passport require a `verify` function, which accept
+//   credentials (in this case, an accessToken, refreshToken, and Linkedin
+//   profile), and invoke a callback with a user object.
+passport.use(new LinkedinStrategy({
+    clientID: LINKEDIN_CLIENT_ID,
+    clientSecret: LINKEDIN_CLIENT_SECRET,
+    callbackURL: "http://localhost:3000/auth/linkedin/callback",
+    scope: ['r_basicprofile', 'r_emailaddress'],
+    passReqToCallback: true
+},
+    function (req, accessToken, refreshToken, profile, done) {
+        // asynchronous verification, for effect...
+        req.session.accessToken = accessToken;
+        process.nextTick(function () {
+            // To keep the example simple, the user's Linkedin profile is returned to
+            // represent the logged-in user.  In a typical application, you would want
+            // to associate the Linkedin account with a user record in your database,
+            // and return that user instead.
+            return done(null, profile);
+        });
+    }
+));
+
+
+
+const app = express();
+
+// configure Express
+app.configure(function () {
+   // app.set('views', __dirname + '/views');
+   // app.set('view engine', 'ejs');
+    app.use(express.logger());
+    app.use(express.cookieParser());
+    app.use(express.urlencoded());
+    app.use(express.json());
+    app.use(express.session({ secret: 'keyboard cat' }));
+    // Initialize Passport!  Also use passport.session() middleware, to support
+    // persistent login sessions (recommended).
+    app.use(passport.initialize());
+    app.use(passport.session());
+    app.use(app.router);
+    app.use(express.static(__dirname + '/public'));
+});
+
+app.get('/', function (req, res) {
+    res.render('index', { user: req.user });
+});
+
+app.get('/account', ensureAuthenticated, function (req, res) {
+    res.render('account', { user: req.user });
+});
+
+// GET /auth/linkedin
+//   Use passport.authenticate() as route middleware to authenticate the
+//   request.  The first step in Linkedin authentication will involve
+//   redirecting the user to linkedin.com.  After authorization, Linkedin
+//   will redirect the user back to this application at /auth/linkedin/callback
+app.get('/auth/linkedin',
+    passport.authenticate('linkedin', { state: 'SOME STATE' }),
+    function (req, res) {
+        // The request will be redirected to Linkedin for authentication, so this
+        // function will not be called.
+    });
+
+// GET /auth/linkedin/callback
+//   Use passport.authenticate() as route middleware to authenticate the
+//   request.  If authentication fails, the user will be redirected back to the
+//   login page.  Otherwise, the primary route function function will be called,
+//   which, in this example, will redirect the user to the home page.
+app.get('/auth/linkedin/callback',
+    passport.authenticate('linkedin', { failureRedirect: '/login' }),
+    function (req, res) {
+        res.redirect('/');
+    });
+
+app.get('/logout', function (req, res) {
+    req.logout();
+    res.redirect('/');
+});
+
+var http = require('http');
+
+http.createServer(app).listen(3000);
+
+
+// Simple route middleware to ensure user is authenticated.
+//   Use this route middleware on any resource that needs to be protected.  If
+//   the request is authenticated (typically via a persistent login session),
+//   the request will proceed.  Otherwise, the user will be redirected to the
+//   login page.
+function ensureAuthenticated(req, res, next) {
+    if (req.isAuthenticated()) { return next(); }
+    res.redirect('/login');
+}


### PR DESCRIPTION
Went back to the original Express code.  I did not like the NPM packages, due to having less control of the data being returned and how it was structured.  You can see all data returned in the new lib folder of OAuth in the root directory.

Created a login.htm, login.js under public.  Server JS contains everything we need to get data from LinkedIn.  I am not sure how we want to structure this, but will need models to create the user data.  We may want to spend some time as team talking this one out.  I will fork this repo once merged and play around with a demo file to see if I can find a good solution.  I think we can still utilize this in React.